### PR TITLE
Added timezone-aware DateTimeProperty subclass

### DIFF
--- a/neo4django/db/models/__init__.py
+++ b/neo4django/db/models/__init__.py
@@ -4,6 +4,6 @@ from base import NodeModel
 
 from relationships import Relationship
 from properties import Property, StringProperty, EmailProperty,\
-        URLProperty,IntegerProperty, DateProperty, DateTimeProperty,\
-        ArrayProperty, StringArrayProperty, IntArrayProperty,\
-        URLArrayProperty, AutoProperty
+        URLProperty, IntegerProperty, DateProperty, DateTimeProperty,\
+        DateTimeTZProperty, ArrayProperty, StringArrayProperty,\
+        IntArrayProperty, URLArrayProperty, AutoProperty

--- a/neo4django/db/models/properties.py
+++ b/neo4django/db/models/properties.py
@@ -23,7 +23,10 @@ from neo4django.constants import AUTO_PROP_INDEX_VALUE
 try:
     from dateutil.tz import tzutc, tzoffset
 except ImportError:
-    # Redefine tzutc and tzoffset classes, borrowed from dateutil
+    # Time zone support requires dateutil.tz.tzutc and dateutil.tz.tzoffset, so
+    # redefining them here. Since the code is borrowed directly from dateutil
+    # (which is BSD-licensed), including the licensing block here too.
+
     # Copyright 2003-2007 Gustavo Niemeyer <gustavo@niemeyer.net>. All rights
     # reserved.
     #

--- a/neo4django/db/models/properties.py
+++ b/neo4django/db/models/properties.py
@@ -130,7 +130,7 @@ class Property(object):
                  has_own_index=False, unique=False, name=None, editable=True,
                  null=True, blank=True, validators=[], choices=None,
                  error_messages=None, required=False, serialize=True,
-                 auto=False, metadata={}, auto_default=NOT_PROVIDED, 
+                 auto=False, metadata={}, auto_default=NOT_PROVIDED,
                  default=NOT_PROVIDED, **kwargs):
         if unique and not indexed:
             raise ValueError('A unique property must be indexed.')
@@ -391,7 +391,7 @@ class BoundProperty(AttrRouter):
             index = None
             if prop.auto and values.get(key, None) is None:
                 type_node = prop.target._type_node(instance.using)
-                
+
                 last_auto_attname = '%s.%s' % (prop.attname, AUTO_PROP_INDEX_VALUE)
 
                 script = prop.next_value_gremlin
@@ -412,7 +412,7 @@ class BoundProperty(AttrRouter):
                 typeNode[lastAutoProp] = value
 
                 lockManager.releaseWriteLock(rawTypeNode, null)
-                
+
                 results = value
                 """
                 conn = connections[instance.using]
@@ -680,7 +680,7 @@ class DateProperty(Property):
             return super(DateProperty, self).pre_save(model_instance, add, attname)
 
 class DateTimeProperty(DateProperty):
-    __format = '%Y-%m-%d-%H:%M:%S.%f'
+    __format = '%Y-%m-%d %H:%M:%S.%f'
 
     default_error_messages = {
         'invalid': _(u'Enter a valid date/time in YYYY-MM-DD HH:MM[:ss[.uuuuuu]] format.'),

--- a/neo4django/db/models/properties.py
+++ b/neo4django/db/models/properties.py
@@ -690,8 +690,10 @@ class DateTimeProperty(DateProperty):
     MIN=datetime.datetime.min
 
     @classmethod
-    def _format_datetime(cls, value):
-        time_string = cls._format_date(value, cls.__format)
+    def _format_datetime(cls, value, format_string=None):
+        if not format_string:
+            format_string = cls.__format
+        time_string = cls._format_date(value, format_string)
         return time_string.replace('%H', str(value.hour).zfill(2))\
                           .replace('%M', str(value.minute).zfill(2))\
                           .replace('%S', str(value.second).zfill(2))\
@@ -747,6 +749,110 @@ class DateTimeProperty(DateProperty):
             return value
         else:
             return super(DateTimeProperty, self).pre_save(model_instance, add, attname)
+
+
+class DateTimeTZProperty(DateTimeProperty):
+    '''
+    DateTimeProperty that can store and retrieve timezone-aware datetimes.
+    '''
+    __format = '%Y-%m-%d %H:%M:%S.%f %z'
+
+    @classmethod
+    def _format_offset(cls, offset_timedelta):
+        '''
+        Produce a timezone offset string (+/- HHMM) from a timedelta.
+        '''
+        try:
+            seconds = offset_timedelta.total_seconds()
+        except AttributeError:
+            # total_seconds method is only available from 2.7 up
+            td = offset_timedelta
+            days_to_secs = td.days * 24 * 3600.0
+            secs_to_micro = (td.seconds + days_to_secs) * (10 ** 6)
+            seconds = (td.microseconds + secs_to_micro) / (10 ** 6)
+        mins = seconds / 60
+        hrs = mins / 60
+        mins = mins % 60
+        return '%+03d%02d' % (hrs, mins)
+
+    @classmethod
+    def _parse_tz(cls, tz_str=None):
+        '''
+        Read a timezone string of the form '+0000' and return a timezone
+        object. If not given, just return UTC.
+        '''
+        tz_str = tz_str.strip() if tz_str else ''  # Ensure no whitespace
+        if (not tz_str) or (tz_str == '+0000') or (tz_str == '-0000'):
+            # Shortcut for the common case where it's UTC, or default
+            return tzutc()
+        # Otherwise, pull out the hours and minutes and construct a
+        # tzoffset(), which requires an offset in seconds
+        hrs = int(tz_str[1:3])
+        mins = int(tz_str[3:5])
+        mult = -1 if (tz_str[0] == '-') else 1
+        offset = mult * ((hrs * 3600) + (mins * 60))
+        return tzoffset('LOCAL', offset)
+
+    @classmethod
+    def _format_datetime_with_tz(cls, value):
+        '''
+        Format a datetime (e.g. for storage in Neo4j) with a timezone offset
+        appended as +/- HHMM.
+        '''
+        formatted = cls._format_datetime(value, cls.__format)
+        if value.utcoffset() is not None:
+            offset_string = " " + cls._format_offset(value.utcoffset())
+        else:
+            offset_string = ""
+        return formatted.replace("%z", offset_string).strip()
+
+    @classmethod
+    def __parse_datetime_string_with_tz(cls, value):
+        '''
+        Parse a stringified datetime into a datetime object, first trying to
+        read a timezone (if one is provided in our format). Uses the superclass
+        method to parse the actual string, and adds any timezone information
+        at the end.
+        '''
+        try:
+            # Try converting with timezone offset. Since strptime is decidedly
+            # inconsistent with support for '%z', this must be done manually:
+            # if a '+HHMM' is present, it'll form the last five characters of
+            # the string
+            dt_val, tz_str = value[:-5], value[-5:]
+            dt_val = dt_val.strip()  # ensure no trailing whitespace
+            tz_info = cls._parse_tz(tz_str)
+        except ValueError:
+            tz_info = None
+            dt_val = value
+        # HACK: Relies on CPython 2.x's double-underscore name-mangling!
+        dt = cls._DateTimeProperty__parse_datetime_string(dt_val)
+        return dt.replace(tzinfo=tz_info)
+
+    def from_neo(self, value):
+        if value is None or value == '':
+            return None
+        if isinstance(value, datetime.datetime):
+            return value
+        if isinstance(value, datetime.date):
+            return datetime.datetime(value.year, value.month, value.day)
+
+        return self.__parse_datetime_string_with_tz(value)
+
+    def to_neo(self, value):
+        result = None
+
+        if value is None:
+            return ''
+        if isinstance(value, datetime.datetime):
+            result = value
+        elif isinstance(value, datetime.date):
+            result = datetime.datetime(value.year, value.month, value.day)
+        else:
+            result = self.__parse_datetime_string_with_tz(value)
+
+        return self._format_datetime_with_tz(result)
+
 
 class ArrayProperty(Property):
     __metaclass__ = ABCMeta

--- a/neo4django/tests/property_tests.py
+++ b/neo4django/tests/property_tests.py
@@ -55,7 +55,6 @@ def test_integer():
         try_int(i)
     
 def test_date_constructor():
-    #TODO make more complete
     class DateNode(models.NodeModel):
         date = models.DateProperty()
 

--- a/neo4django/tests/property_tests.py
+++ b/neo4django/tests/property_tests.py
@@ -8,6 +8,10 @@ def setup():
 
     from neo4django.tests import Person, neo4django, gdb, neo4jrestclient, \
             neo_constants, settings, models
+    try:
+        from dateutil.tz import tzutc, tzoffset
+    except ImportError:
+        from models.properties import tzutc, tzoffset
 
 def teardown():
     gdb.cleandb()
@@ -51,8 +55,15 @@ def test_integer():
         try_int(i)
     
 def test_date_constructor():
-    #TODO
-    pass
+    #TODO make more complete
+    class DateNode(models.NodeModel):
+        date = models.DateProperty()
+
+    today = datetime.date.today()
+    d = DateNode(date=today)
+    assert d.date == today
+    d.save()
+    assert d.date == today
 
 def test_date_prop():
     #TODO
@@ -159,6 +170,44 @@ def test_date_auto_now_add():
     ##Confrim the date doesn't change when no other property changes
     b.save()
     assert b.date_made == date1
+
+def test_datetime_prop():
+    # TODO
+    pass
+
+def test_datetime_auto_now():
+    from time import sleep
+    class BlogNode(models.NodeModel):
+        title = models.Property()
+        date_modified = models.DateTimeProperty(auto_now = True)
+    timediff = .6 #can be this far apart
+    ##Confirm the date auto sets on creation
+
+def test_datetimetz_constructor():
+    class DateTimeTZNode(models.NodeModel):
+        datetime = models.DateTimeTZProperty()
+
+    time = datetime.datetime.now(tzinfo=tzoffset('LOCAL', 3600))
+    d = DateTimeTZNode(datetime=time)
+    assert d.datetime == time
+    d.save()
+    assert d.datetime == time
+    assert d.datetime.astimezone(tz=tzutc()) == time.astimezone(tz=tzutc())
+
+def test_datetimetz_prop():
+    class DateTimeTZNode(models.NodeModel):
+        datetime = models.DateTimeTZProperty()
+
+    time = datetime.datetime.now(tzinfo=tzoffset('DST', 3600))
+    d = DateTimeNode(datetime=time)
+    assert d.datetime == time
+    # Now some low-level attribute access stuff to make sure it's loading /
+    # storing correctly
+    dt_prop = DateTimeTZNode.dt._property
+    assert dt_prop.to_neo(d.datetime) == d.datetime.strftime(
+        models.DateTimeTZProperty._DateTimeTZProperty__format)
+    # Test roundtrip
+    assert d.datetime == dt_prop.from_neo(dt_prop.to_neo(d.datetime))
 
 def test_array_property_validator():
     """Tests that ArrayProperty validates properly."""


### PR DESCRIPTION
Adds a timezone-aware DateTimeProperty subclass DateTimeTZProperty, using dateutil.tz (or locally redefined classes) to represent timezone offsets. Should be fully backward-compatible with DateTimeProperty. Also added tests.
