### PR TITLE
Small fix in BaseModel._type_node for Neo4j 1.6 compatibility

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -371,7 +371,7 @@ class NodeModel(NeoModel):
             locked << rawVertex
 
             candidate = curVertex.outE('<<TYPE>>').inV.find{
-                it.map.subMap(typeProps.keySet()) == typeProps
+                it.map().subMap(typeProps.keySet()) == typeProps
             }
             if (candidate == null) {
                 newTypeNode = g.addVertex(typeProps)


### PR DESCRIPTION
In Neo4j 1.6, the "it.map" property on a node returns another step
in the GremlinGroovyPipeline rather than evaluating to a property
map (on which subMap() can be called to check properties against
those we're looking for). This fix forces evaluation, so that it
works in both 1.5 and 1.6.
