### PR TITLE
Some fixes for id__in and qs in general

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -38,7 +38,10 @@ class IdLookup(object):
     index = property(lambda self: self)
     
     def to_neo(self, value):
-        return int(value)
+        if value is not None:
+            return int(value)
+        else: # Allows lookups on Nulls
+            return value
     
     def nodes(self, nodeid):
         #TODO is this dead code?

--- a/neo4django/db/models/manager.py
+++ b/neo4django/db/models/manager.py
@@ -21,6 +21,10 @@ class NodeModelManager(models.Manager):
     def get_empty_query_set(self):
         pass
 
+    @not_implemented
+    def exclude(self, *args, **kwargs):
+        pass
+
     def get_query_set(self):
         return NodeQuerySet(self.model)
 
@@ -37,4 +41,6 @@ class NodeModelManager(models.Manager):
         return self.get_query_set().create(**kwargs)
     
     def filter(self, *args, **kwargs):
+        if args:
+            raise NotImplementedError('The Q operator is not currently supported')
         return self.get_query_set().filter(**kwargs)

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -467,7 +467,7 @@ class Query(object):
                 ##                     take more than 250 elements by itself.
                 ##                     According to gremlin devs, this is equiv
                 gremlin_script = 'list=[%s];res=[];list.each{res.add(g.v(it))};res._()'
-                gremlin_script %= ','.join(str(i) for i in id_set)
+                gremlin_script %= ','.join(str(i) for i in id_set if i is not None)
                 nodes = ext.execute_script(gremlin_script)
                 ## TODO: HACKS: We don't know type coming out of neo4j-rest-client
                 #               so we check it hackily here.

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -424,13 +424,15 @@ class Query(object):
     #TODO when does a returned index query of len 0 mean we're done?
     def execute(self, using):
         conditions = uniqify(self.conditions)
-
+        
         #TODO exclude those that can't be evaluated against (eg exact=None, etc)
         id_conditions = []
         indexed = []
         unindexed = []
 
         for c in conditions:
+            # if c.negate:
+            #     raise NotImplementedError('Negative conditions (eg .exclude() are not supported')
             if getattr(c.field, 'id', False):
                 id_conditions.append(c)
             elif c.field.indexed:

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -480,8 +480,9 @@ class Query(object):
                         yield self.model_from_node(node)
                 return
             else:
-                raise ValueError('Conflicting id__in lookups - the intersection'
-                                 ' of the queried id lists is empty.')
+                return ## Emulates django's behavior
+                # raise ValueError('Conflicting id__in lookups - the intersection'
+                #                  ' of the queried id lists is empty.')
                                                       
         #TODO order by type - check against the global type first, so that if
         #we get an empty result set, we can return none? this kind of impedes Q

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -440,7 +440,8 @@ class Query(object):
             else:
                 unindexed.append(c)
 
-        id_lookups = dict(itertools.groupby(id_conditions, lambda c: c.operator))
+        grouped_id_conds = itertools.groupby(id_conditions, lambda c: c.operator)
+        id_lookups = dict(((k, list(l)) for k, l in grouped_id_conds))
         exact_id_lookups = list(id_lookups.get(OPERATORS.EXACT, []))
         #if we have an exact lookup, do it and return
         if len(exact_id_lookups) == 1:

--- a/neo4django/tests/nodequeryset_tests.py
+++ b/neo4django/tests/nodequeryset_tests.py
@@ -294,6 +294,14 @@ def test_in_id():
         ).filter(id__in=(interesting_man.id, uninteresting_man.id))
     eq_(len(only_interesting), 1)
 
+    only_interesting = Person.objects.filter(
+        id__in=(interesting_man.id,)
+        ).filter(id__in=(uninteresting_man.id,))
+    eq_(len(only_interesting), 0)
+    
+    # Passing in an empty qs -- replicate django
+    eq_(len(Person.objects.filter(id__in=[])), 0)
+
 def setup_teens():
     setup_people()
     make_people(['Tina', 'Rob', 'Tiny Tim'], [13, 15, 12])

--- a/neo4django/tests/nodequeryset_tests.py
+++ b/neo4django/tests/nodequeryset_tests.py
@@ -302,6 +302,9 @@ def test_in_id():
     # Passing in an empty qs -- replicate django
     eq_(len(Person.objects.filter(id__in=[])), 0)
 
+    # Passing in qs with None -- replicate django
+    eq_(len(Person.objects.filter(id__in=[uninteresting_man.id, None])), 1)
+
 def setup_teens():
     setup_people()
     make_people(['Tina', 'Rob', 'Tiny Tim'], [13, 15, 12])

--- a/neo4django/tests/nodequeryset_tests.py
+++ b/neo4django/tests/nodequeryset_tests.py
@@ -272,7 +272,7 @@ def test_in_id():
     uninteresting_man = Person.objects.create(name=boring_name, age=boring_age)
 
     Person.objects.create(age=boring_age)
-
+    
     people = list(Person.objects.filter(id__in=(interesting_man.id, uninteresting_man.id)))
     eq_(len(people), 2)
     eq_([boring_age, age], sorted(p.age for p in people))
@@ -287,6 +287,12 @@ def test_in_id():
 
     no_people = list(Person.objects.filter(id__in=(1000,)))
     eq_(len(no_people), 0)
+
+    # Test chaining
+    only_interesting = Person.objects.filter(
+        id__in=(interesting_man.id,)
+        ).filter(id__in=(interesting_man.id, uninteresting_man.id))
+    eq_(len(only_interesting), 1)
 
 def setup_teens():
     setup_people()


### PR DESCRIPTION
Includes:
- Chaining now works properly
- .exclude now raises a `NotImplemented`, as does any query containing a `Q()`
- id__in allows None to be passed in (like django)
- id__in allows empty lists and lists that yield empty list on overlap (like django)

Let me know your thoughts.
