### PR TITLE
Hotfix relationship cache duplicates

### DIFF
--- a/neo4django/db/models/relationships.py
+++ b/neo4django/db/models/relationships.py
@@ -602,9 +602,13 @@ class RelationshipInstance(models.Manager):
                 self._cache.append(pair)
                 self._cache_unique.add(pair)
 
-    def _remove_from_cache(self, pair):
-        self._cache.remove(pair)
-        self._cache_unique.remove(pair)
+    def _remove_from_cache(self, obj):
+        for r, cached_obj in self._cache[:]:
+            if cached_obj == obj:
+                pair = (r, cached_obj)
+                self._cache.remove(pair)
+                self._cache_unique.remove(pair)
+                break
 
     def __save__(self, node):
         #Deletes all relationships removed since last save and adds any new
@@ -675,6 +679,7 @@ class RelationshipInstance(models.Manager):
                         self._added.remove(obj)
                     except ValueError:
                         raise rel.target_model.DoesNotExist("%r is not related to %r." % (obj, self.__obj))
+                self._remove_from_cache(obj)
         else:
             for obj in objs:
                 try:

--- a/neo4django/tests/relationship_tests.py
+++ b/neo4django/tests/relationship_tests.py
@@ -56,6 +56,13 @@ def test_basic_relationship_manager():
     other_paper.authors.clear()
     eq_(list(other_paper.authors.all()), [])
 
+    ## Test to make sure we don't end up with duplicates
+    ## When we do two saves in a row after clearing
+    other_paper.save()
+    other_paper.authors.add(pete)
+    other_paper.save()
+    eq_(len(list(other_paper.authors.all())), 1)
+
 def test_one_to_many():
     class Origin1(models.NodeModel):
         name = models.StringProperty()


### PR DESCRIPTION
There were some funny edge cases with clear -- if you save an object, clear the relationships, and then save it again, the cache ended up in a funny state, to solve this, I check for duplicates in the cache. Also, objects were not being properly removed from the cache in clear.

Let me know if I overlooked anything major.
