### PR TITLE
Fixed a syntax error in the test database code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ configured at port 7475, and your cleandb install were pointing to
 
     NEO4J_TEST_DATABASES = {
         'default': {
-            'HOST': 'localhost",
+            'HOST': 'localhost',
             'PORT': 7475,
             'ENDPOINT': '/db/data',
             'OPTIONS': {


### PR DESCRIPTION
Fixed a syntax error in the test code example. (EOL while scanning string literal)
