### PR TITLE
Install own instance of Neo4j for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ python:
   - "2.6"
   - "2.7"
 before_install:
-  - which neo4j && sudo neo4j start
+  - ./install_local_neo4j.bash $NEO4J_VERSION
+  - cd lib/neo4j && ./bin/neo4j start && cd ../../
   - sleep 3
 install: pip install --use-mirrors -r requirements.txt -r test_requirements.txt
 env:
-  - DJANGO_SETTINGS_MODULE="neo4django.tests.test_settings"
+  - DJANGO_SETTINGS_MODULE="neo4django.tests.test_settings" NEO4J_VERSION="1.5"
+  - DJANGO_SETTINGS_MODULE="neo4django.tests.test_settings" NEO4J_VERSION="1.6"
+  - DJANGO_SETTINGS_MODULE="neo4django.tests.test_settings" NEO4J_VERSION="1.7"
 script:
-  - nosetests --with-regression
+  - nosetests --with-regression --verbose

--- a/install_local_neo4j.bash
+++ b/install_local_neo4j.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DEFAULT_VERSION="1.6"
+VERSION=${1-$DEFAULT_VERSION}
+DIR="neo4j-community-$VERSION"
+FILE="$DIR-unix.tar.gz"
+SERVER_PROPERTIES_FILE="lib/neo4j/conf/neo4j-server.properties"
+
+if [[ ! -d lib/$DIR ]]; then
+    wget http://dist.neo4j.org/$FILE
+    tar xvfz $FILE &> /dev/null
+    rm $FILE
+    [[ ! -d lib ]] && mkdir lib
+    mv $DIR lib/
+    [[ -h lib/neo4j ]] && unlink lib/neo4j
+    ln -fs $DIR lib/neo4j
+    mkdir lib/neo4j/testing/
+    DELETE_DB_PLUGIN_JAR="test-delete-db-extension-1.6.jar"
+    wget --no-check-certificate -O lib/neo4j/testing/$DELETE_DB_PLUGIN_JAR https://github.com/downloads/jexp/neo4j-clean-remote-db-addon/$DELETE_DB_PLUGIN_JAR
+    ln -s ../testing/$DELETE_DB_PLUGIN_JAR lib/neo4j/plugins/$DELETE_DB_PLUGIN_JAR
+    cat >> $SERVER_PROPERTIES_FILE <<EOF
+org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.server.extension.test.delete=/cleandb
+org.neo4j.server.thirdparty.delete.key=supersecretdebugkey!
+EOF
+fi


### PR DESCRIPTION
Travis provides a Neo4j instance, but with this method, we can test
against multiple versions of Neo4j (and have cleardb installed)
