### PR TITLE
Include (currently failing) test for `in_bulk([unknown_id])`

### DIFF
--- a/neo4django/tests/nodequeryset_tests.py
+++ b/neo4django/tests/nodequeryset_tests.py
@@ -454,6 +454,14 @@ def test_in_bulk():
     eq_(people[interesting_man.id].name, name)
     eq_([boring_age, age], sorted(p.age for p in people.values()))
 
+@with_setup(setup_people, teardown)
+def test_in_bulk_not_found():
+    """
+    Tests QuerySet.in_builk() with items not found.
+    """
+    people = Person.objects.in_bulk([999999])
+    eq_(people, [])
+
 @with_setup(setup_mice_and_people, teardown)
 def test_contains():
     q1 = Person.objects.filter(name__contains='a')


### PR DESCRIPTION
(TL;DR: Incomplete pull request; so far just a test highlighting a bug)

When attempting to do `NodeModel.objects.in_bulk([unknown_id])`, as the included test does, I get the following barfage:

```
======================================================================
ERROR: Tests QuerySet.in_builk() with items not found.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kristian/git/neo4django/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/kristian/git/neo4django/neo4django/tests/nodequeryset_tests.py", line 462, in test_in_bulk_not_found
    people = Person.objects.in_bulk([999999])
  File "/Users/kristian/git/neo4django/lib/python2.7/site-packages/django/db/models/manager.py", line 158, in in_bulk
    return self.get_query_set().in_bulk(*args, **kwargs)
  File "/Users/kristian/git/neo4django/neo4django/db/models/query.py", line 663, in in_bulk
    return dict((o.id, o) for o in self.model.objects.filter(id__in=id_list))
  File "/Users/kristian/git/neo4django/neo4django/db/models/query.py", line 663, in <genexpr>
    return dict((o.id, o) for o in self.model.objects.filter(id__in=id_list))
  File "/Users/kristian/git/neo4django/lib/python2.7/site-packages/django/db/models/query.py", line 118, in _result_iter
    self._fill_cache()
  File "/Users/kristian/git/neo4django/lib/python2.7/site-packages/django/db/models/query.py", line 875, in _fill_cache
    self._result_cache.append(self._iter.next())
  File "/Users/kristian/git/neo4django/neo4django/db/models/query.py", line 634, in iterator
    for model in self.query.execute(using):
  File "/Users/kristian/git/neo4django/neo4django/db/models/query.py", line 466, in execute
    nodes = connections[using].gremlin_tx(script, ids=list(id_set))
  File "/Users/kristian/git/neo4django/neo4django/neo4jclient.py", line 153, in gremlin_tx
    return self.gremlin(script, tx=True, **params)
  File "/Users/kristian/git/neo4django/neo4django/neo4jclient.py", line 142, in gremlin
    params)
  File "/Users/kristian/git/neo4django/neo4django/neo4jclient.py", line 130, in send_script
    script_rv = ext.execute_script(s, params=params, **execute_kwargs)
  File "/Users/kristian/git/neo4django/src/neo4jrestclient/neo4jrestclient/client.py", line 1922, in __call__
    returns = result[0].get("self", None)
AttributeError: 'unicode' object has no attribute 'get'
```

From `query.py`:

```
@transactional
def in_bulk(self, id_list):
    return dict((o.id, o) for o in self.model.objects.filter(id__in=id_list))
```

Now, if I use `filter()` directly:

```
>>> StackExchangeUser.objects.filter(id__in=[33])
[]
```

However that's not an empty list, it's a `NodeQuerySet`. I'm still trying to get to the cause of this barf-on-iteration, but this is a preliminary pull request with "here's where I'm at and reproduction steps" in case someone can fix it faster / better / before me...

Thanks!
