### PR TITLE
Fix test memoization

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -392,7 +392,7 @@ class NodeModel(NeoModel):
         if not hasattr(script_rv, 'properties'):
             raise RuntimeError(error_message + '\n\n%s' % script_rv)
         return script_rv
-    if not settings.DEBUG:
+    if not settings.DEBUG and getattr(settings, 'RUNNING_NEO4J_TESTS', None):
         _type_node = memoized(_type_node)
     _type_node = classmethod(_type_node)
 

--- a/neo4django/testutils.py
+++ b/neo4django/testutils.py
@@ -13,6 +13,7 @@ class NodeModelTestCase(django_test.TestCase):
         ##       TestCase and a custom runner?
         super(NodeModelTestCase, self).__init__(*args, **kwargs)
         _settings.NEO4J_DATABASES = _settings.NEO4J_TEST_DATABASES
+        _settings.RUNNING_NEO4J_TESTS = True
         new_connections = ConnectionHandler(_settings.NEO4J_TEST_DATABASES)
         for alias in new_connections:
             connections[alias] = new_connections[alias]


### PR DESCRIPTION
Fix to move memoization switch from import to on-access. This way we don't have to instantiate NodeModelTestCase before importing NeoModel or any of its subclasses.
