### PR TITLE
Also install neo4django.auth when using setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='A Django/Neo4j ORM layer.',
     license = 'GPL',
     url = "https://neo4django.readthedocs.org/en/latest/",
-    packages=['neo4django','neo4django.db','neo4django.db.models','neo4django.tests', 'neo4django.gremlin'],
+    packages=['neo4django','neo4django.auth','neo4django.db','neo4django.db.models','neo4django.tests', 'neo4django.gremlin'],
     package_dir={'neo4django':'neo4django'},
     package_data={'neo4django':['gremlin/*.groovy']},
     long_description=open('README.rst').read(),


### PR DESCRIPTION
This changes the setup.py to also install neo4django.auth, since the documentation looks like that's the supposed behaviour (?).
