### PR TITLE
Use class-specific meta_additions

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -74,7 +74,7 @@ class NeoModelBase(type(dj_models.Model)):
         attr_meta = attrs.get('Meta', None)
         extra_options = {}
         if attr_meta:
-            for key in NeoModelBase.meta_additions:
+            for key in set(NeoModelBase.meta_additions + cls.meta_additions):
                 if hasattr(attr_meta, key):
                     extra_options[key] = getattr(attr_meta, key)
                     delattr(attr_meta, key)


### PR DESCRIPTION
Referring specifically to `NeoModelBase.meta_additions` prevents subclasses from adding additional attributes to `Meta`. Combining both the base meta_additions of NeoModelBase and those of the `cls` argument should allow better flexibility while ensuring "has_own_index" stays intact.
