### PR TITLE
Tastypie compatibility

### DIFF
--- a/neo4django/db/models/properties.py
+++ b/neo4django/db/models/properties.py
@@ -28,7 +28,7 @@ MIN_INT = -9223372036854775808
 MAX_INT = 9223372036854775807
 
 FIELD_PASSTHROUGH_METHODS = ('formfield','get_flatchoices','_get_flatchoices',
-                             'set_attributes_from_name', 'get_internal_type')
+                             'set_attributes_from_name')
 
 
 @borrows_methods(fields.Field, FIELD_PASSTHROUGH_METHODS)
@@ -144,6 +144,24 @@ class Property(object):
         that don't support said option need not be concerned.
         """
         return self.to_neo(value)
+
+    def get_internal_type(self):
+        """
+        Returns the "internal" type of an object which instructs API handlers
+        like Tastypie how to represent the field etc.
+
+        Since all those external libraries expect the Django names like
+        "DateTimeField" and our classes are named "DateTimeProperty", we have to
+        replace all "Property"s with "Field". Also, rename "StringField" to
+        "CharField".
+        """
+
+        classname = self.__class__.__name__
+
+        if classname == 'StringProperty':
+            return 'CharField'
+
+        return classname.replace("Property", "Field")
 
     def contribute_to_class(self, cls, name):
         """

--- a/neo4django/db/models/properties.py
+++ b/neo4django/db/models/properties.py
@@ -28,7 +28,7 @@ MIN_INT = -9223372036854775808
 MAX_INT = 9223372036854775807
 
 FIELD_PASSTHROUGH_METHODS = ('formfield','get_flatchoices','_get_flatchoices',
-                             'set_attributes_from_name')
+                             'set_attributes_from_name', 'get_internal_type')
 
 
 @borrows_methods(fields.Field, FIELD_PASSTHROUGH_METHODS)
@@ -264,6 +264,9 @@ class BoundProperty(AttrRouter):
                      'meta',
                      'MAX',
                      'MIN',
+                     'get_internal_type',
+                     'help_text',
+                     'null',
                      #form-related properties
                      'editable',
                      'blank',

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -764,6 +764,7 @@ class Query(object):
         self.distinct_fields = None
 
         self.standard_ordering = True
+        self.query_terms = None
 
         # XXX to handle overreaching django code like in the admin - not used
         # otherwise

--- a/neo4django/db/models/relationships.py
+++ b/neo4django/db/models/relationships.py
@@ -58,7 +58,7 @@ class Relationship(object):
     def __init__(self, target, rel_type=None, direction=None, optional=True,
                  single=False, related_single=False, related_name=None,
                  editable=True, verbose_name=None, help_text=None,
-                 preserve_ordering=False, metadata={},
+                 preserve_ordering=False, null = True, metadata={},
                  rel_metadata={}):
         if direction is Outgoing:
             direction = RELATIONSHIPS_OUT
@@ -89,6 +89,7 @@ class Relationship(object):
         self.optional = optional
         self.verbose_name = verbose_name
         self.help_text = help_text
+        self.null = null
 
     target_model = property(lambda self: self.__target)
     ordered = property(lambda self: self.__ordered)
@@ -126,6 +127,12 @@ class Relationship(object):
         else:
             name = target.__name__
         return suffix % name.lower()
+
+    def get_internal_type(self):
+        return "Neo4jRelationship"
+
+    def has_default(self):
+        return False
 
     def _get_bound_relationship_type(self):
         # TODO this will change with relationship models (#1)
@@ -224,6 +231,10 @@ class BoundRelationship(AttrRouter, DeferredAttribute):
                      'target_model',
                      'ordered',
                      'meta',
+                     'get_internal_type',
+                     'help_text',
+                     'null',
+                     'has_default',
                      # form handling
                      'editable',
                      'formfield',


### PR DESCRIPTION
This patch makes neo4django compatible with the tastypie API framework by adding the `get_internal_type` function and some variables to the model and relationship base classes.
