### PR TITLE
fixes scholrly/neo4django#199

### DIFF
--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -353,7 +353,7 @@ def cypher_predicate_from_condition(element_name, condition):
         if isinstance(field._property, StringProperty):
             #TODO this is a poor man's excuse for Java regex escaping. we need
             # a better solution
-            regex = ('.*%s.*' % re.escape(value))
+            regex = ('.*%s.*' % re.sub('"\'`;:{}\(\)\|', '', value) )
             cypher = '%s =~ %s' % (element_name, cypher_primitive(regex))
         else:
             raise exceptions.ValidationError('The contains operator is only'

--- a/neo4django/db/models/relationships.py
+++ b/neo4django/db/models/relationships.py
@@ -727,10 +727,10 @@ class RelationshipInstance(models.Manager):
             rels_by_node = defaultdict(list)
             for neo_rel in neo_rels:
                 other_end = neo_rel.start if neo_rel.end == self._obj.node else neo_rel.end
-                rels_by_node[other_end].append(neo_rel)
+                rels_by_node[other_end.url].append(neo_rel)
 
             for obj in objs:
-                candidate_rels = rels_by_node[obj.node] if hasattr(obj, 'node') else []
+                candidate_rels = rels_by_node[obj.node.url] if hasattr(obj, 'node') else []
                 if candidate_rels:
                     if candidate_rels[0] not in self._removed:
                         self._removed.append(candidate_rels.pop(0))


### PR DESCRIPTION
We use now an url to retrieve the relationship to remove. This also fixes the Relationship's clear() method ;)

The mistake was into the defaultdict lookup that use a Node class as key among LazyNode elements. 
