### PR TITLE
Added patch to remove basic authentication part during connection research

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -152,7 +152,7 @@ class NodeModel(NeoModel):
         for name in connections:
             connection_url = connections[name].url
             # Remove the authentication part
-            connection_url = re.sub("htTp(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
+            connection_url = re.sub("http(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
 
             if connection_url in neo_node.url:
                 names.append(name)

--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -17,6 +17,7 @@ from .manager import NodeModelManager
 
 import inspect
 import itertools
+import re
 from decorator import decorator
 
 
@@ -145,10 +146,17 @@ class NodeModel(NeoModel):
         #A factory method to create NodeModels from a neo4j node.
         instance = cls.__new__(cls)
         instance.__node = neo_node
-
+        
         #take care of using by inferring from the neo4j node
-        names = [name for name in connections
-                 if connections[name].url in neo_node.url]
+        names = []
+        for name in connections:
+            connection_url = connections[name].url
+            # Remove the authentication part
+            connection_url = re.sub("htTp(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
+
+            if connection_url in neo_node.url:
+                names.append(name)
+
         if len(names) < 1:
             raise NoSuchDatabaseError(url=neo_node.url)
 


### PR DESCRIPTION
Hi,

When I tired to use a Neo4j hostname containing basic authentication, neo4django can't retrieve the connection matching to a node's url. So I removed the authentication part into the connection name during the node's research. It works now!

Here the orignal traceback:

```
Exception Type: NoSuchDatabaseError at /admin/
Exception Value: No such database exists: %s

Traceback:
File "/app/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                         response = callback(request, *callback_args, **callback_kwargs)
File "/app/lib/python2.7/site-packages/django/contrib/admin/sites.py" in wrapper
  213.                 return self.admin_view(view, cacheable)(*args, **kwargs)
File "/app/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  91.                     response = view_func(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  89.         response = view_func(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  195.                 return self.login(request)
File "/app/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  89.         response = view_func(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/contrib/admin/sites.py" in login
  326.         return login(request, **defaults)
File "/app/lib/python2.7/site-packages/django/views/decorators/debug.py" in sensitive_post_parameters_wrapper
  69.             return view(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  91.                     response = view_func(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  89.         response = view_func(request, *args, **kwargs)
File "/app/lib/python2.7/site-packages/django/contrib/auth/views.py" in login
  36.         if form.is_valid():
File "/app/lib/python2.7/site-packages/django/forms/forms.py" in is_valid
  124.         return self.is_bound and not bool(self.errors)
File "/app/lib/python2.7/site-packages/django/forms/forms.py" in _get_errors
  115.             self.full_clean()
File "/app/lib/python2.7/site-packages/django/forms/forms.py" in full_clean
  271.         self._clean_form()
File "/app/lib/python2.7/site-packages/django/forms/forms.py" in _clean_form
  299.             self.cleaned_data = self.clean()
File "/app/lib/python2.7/site-packages/django/contrib/admin/forms.py" in clean
  26.             self.user_cache = authenticate(username=username, password=password)
File "/app/lib/python2.7/site-packages/django/contrib/auth/__init__.py" in authenticate
  45.             user = backend.authenticate(**credentials)
File "/app/lib/python2.7/site-packages/neo4django/auth/backends.py" in authenticate
  14.             user = User.objects.get(username=username)
File "/app/lib/python2.7/site-packages/neo4django/db/models/manager.py" in get
  37.         return self.get_query_set().get(*args, **kwargs)
File "/app/lib/python2.7/site-packages/django/db/models/query.py" in get
  361.         num = len(clone)
File "/app/lib/python2.7/site-packages/django/db/models/query.py" in __len__
  85.                 self._result_cache = list(self.iterator())
File "/app/lib/python2.7/site-packages/neo4django/db/models/query.py" in iterator
  1283.                 piece = list(clone.execute(using))
File "/app/lib/python2.7/site-packages/neo4django/db/models/query.py" in execute
  1170.         model_results = [self.model_from_node(n) for n in result_set]
File "/app/lib/python2.7/site-packages/neo4django/db/models/query.py" in model_from_node
  843.         return self.model._neo4j_instance(node)
File "/app/lib/python2.7/site-packages/neo4django/db/models/base.py" in _neo4j_instance
  153.             raise NoSuchDatabaseError(url=neo_node.url)
```
