### PR TITLE
Backend fix User model (avoid from_model trick)

### DIFF
--- a/neo4django/db/models/cypher.py
+++ b/neo4django/db/models/cypher.py
@@ -212,7 +212,7 @@ class OrderByTerm(Cypher):
 
     def get_params(self):
         return {
-            'expr':unicode(self.expression),
+            'expr': unicode(self.expression),
             'desc':'DESC' if self.negate else ''
         }
     

--- a/neo4django/db/models/cypher.py
+++ b/neo4django/db/models/cypher.py
@@ -212,7 +212,7 @@ class OrderByTerm(Cypher):
 
     def get_params(self):
         return {
-            'expr': unicode(self.expression),
+            'expr':unicode(self.expression),
             'desc':'DESC' if self.negate else ''
         }
     

--- a/neo4django/graph_auth/backends.py
+++ b/neo4django/graph_auth/backends.py
@@ -13,7 +13,6 @@ class NodeModelBackend(object):
     supports_inactive_user = False
 
     def authenticate(self, username=None, password=None):
-        UserModel = get_user_model()
         try:
             user = UserModel.objects.get(username=username)
             if user is not None and user.check_password(password):
@@ -22,7 +21,6 @@ class NodeModelBackend(object):
             pass
 
     def get_user(self, user_id):
-        UserModel = get_user_model()
         try:
             return UserModel.objects.get(id=user_id)
         except UserModel.DoesNotExist:

--- a/neo4django/graph_auth/backends.py
+++ b/neo4django/graph_auth/backends.py
@@ -10,12 +10,12 @@ class NodeModelBackend(object):
     supports_inactive_user = False
 
     def authenticate(self, username=None, password=None):
+        UserModel = get_user_model()
         try:
-            UserModel = get_user_model()
             user = UserModel.objects.get(username=username)
             if user is not None and user.check_password(password):
                 return user
-        except User.DoesNotExist:
+        except UserModel.DoesNotExist:
             pass
 
     def get_user(self, user_id):

--- a/neo4django/graph_auth/backends.py
+++ b/neo4django/graph_auth/backends.py
@@ -1,4 +1,3 @@
-from .models import User
 from django.contrib.auth import get_user_model
 
 

--- a/neo4django/graph_auth/backends.py
+++ b/neo4django/graph_auth/backends.py
@@ -1,4 +1,5 @@
 from .models import User
+from django.contrib.auth import get_user_model
 
 
 class NodeModelBackend(object):
@@ -11,7 +12,7 @@ class NodeModelBackend(object):
 
     def authenticate(self, username=None, password=None):
         try:
-            user = User.objects.get(username=username)
+            user = get_user_model().objects.get(username=username)
             if user is not None and user.check_password(password):
                 return user
         except User.DoesNotExist:

--- a/neo4django/graph_auth/backends.py
+++ b/neo4django/graph_auth/backends.py
@@ -12,14 +12,16 @@ class NodeModelBackend(object):
 
     def authenticate(self, username=None, password=None):
         try:
-            user = get_user_model().objects.get(username=username)
+            UserModel = get_user_model()
+            user = UserModel.objects.get(username=username)
             if user is not None and user.check_password(password):
                 return user
         except User.DoesNotExist:
             pass
 
     def get_user(self, user_id):
+        UserModel = get_user_model()
         try:
-            return User.objects.get(id=user_id)
-        except User.DoesNotExist:
+            return UserModel.objects.get(id=user_id)
+        except UserModel.DoesNotExist:
             return None

--- a/neo4django/tests/test_settings.py
+++ b/neo4django/tests/test_settings.py
@@ -48,7 +48,8 @@ DATABASE_ROUTERS = ['neo4django.utils.Neo4djangoIntegrationRouter']
 USE_TZ = True
 
 INSTALLED_APPS = (
-    'neo4django.tests',   
+    'neo4django.tests',
+    'neo4django.graph_auth', 
 )
 
 SECRET_KEY="shutupdjangowe'retryingtotesthere"


### PR DESCRIPTION
Using `authenticate` gave always `graph_auth.User`.
Taken from django's auth, `get_user_model` will ensure your own `AUTH_USER_MODEL` is returned instead.
