### PR TITLE
Disable case sensitive in ORDER BY clause

### DIFF
--- a/neo4django/db/models/cypher.py
+++ b/neo4django/db/models/cypher.py
@@ -329,7 +329,7 @@ class With(Clause):
 
 
 class OrderBy(Clause):
-    cypher_template = 'ORDER BY %(fields)s'
+    cypher_template = 'ORDER BY lower(%(fields)s)'
 
     def __init__(self, terms):
         self.terms = terms


### PR DESCRIPTION
This simple addition makes "order by" case insensitive (which is the default behavior with other Django db backends ;).
