### PR TITLE
Removed lowercase on Order By

### DIFF
--- a/neo4django/db/models/cypher.py
+++ b/neo4django/db/models/cypher.py
@@ -212,8 +212,8 @@ class OrderByTerm(Cypher):
 
     def get_params(self):
         return {
-            'expr': 'LOWER(%s)' % unicode(self.expression),
-            'desc': 'DESC' if self.negate else ''
+            'expr': unicode(self.expression),
+            'desc':'DESC' if self.negate else ''
         }
     
     @property

--- a/neo4django/db/models/cypher.py
+++ b/neo4django/db/models/cypher.py
@@ -212,8 +212,8 @@ class OrderByTerm(Cypher):
 
     def get_params(self):
         return {
-            'expr':unicode(self.expression),
-            'desc':'DESC' if self.negate else ''
+            'expr': 'LOWER(%s)' % unicode(self.expression),
+            'desc': 'DESC' if self.negate else ''
         }
     
     @property
@@ -329,7 +329,7 @@ class With(Clause):
 
 
 class OrderBy(Clause):
-    cypher_template = 'ORDER BY lower(%(fields)s)'
+    cypher_template = 'ORDER BY %(fields)s'
 
     def __init__(self, terms):
         self.terms = terms


### PR DESCRIPTION
For now, we can't use the LOWER() method with a combination of escaped expression and ? symbol. So I removed my fix, sorry for that!
