### PR TITLE
Allow nullable fields with "__icontains"

### DIFF
--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -152,7 +152,7 @@ class NodeModel(NeoModel):
         for name in connections:
             connection_url = connections[name].url
             # Remove the authentication part
-            connection_url = re.sub("htTp(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
+            connection_url = re.sub("http(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
 
             if connection_url in neo_node.url:
                 names.append(name)

--- a/neo4django/db/models/base.py
+++ b/neo4django/db/models/base.py
@@ -17,6 +17,7 @@ from .manager import NodeModelManager
 
 import inspect
 import itertools
+import re
 from decorator import decorator
 
 
@@ -145,10 +146,17 @@ class NodeModel(NeoModel):
         #A factory method to create NodeModels from a neo4j node.
         instance = cls.__new__(cls)
         instance.__node = neo_node
-
+        
         #take care of using by inferring from the neo4j node
-        names = [name for name in connections
-                 if connections[name].url in neo_node.url]
+        names = []
+        for name in connections:
+            connection_url = connections[name].url
+            # Remove the authentication part
+            connection_url = re.sub("htTp(s?)\:\/\/\w+:\w+\@", "", connection_url, flags=re.I)
+
+            if connection_url in neo_node.url:
+                names.append(name)
+
         if len(names) < 1:
             raise NoSuchDatabaseError(url=neo_node.url)
 

--- a/neo4django/db/models/query.py
+++ b/neo4django/db/models/query.py
@@ -420,8 +420,9 @@ def cypher_predicates_from_q(q):
         if getattr(q.field, 'id', False):
             value_exp = 'ID(%s)' % identifier
         else:
-            value_exp = '%s.%s!' % (identifier, q.field.attname)
-        return '(%s)' % cypher_predicate_from_condition(value_exp, q)
+            value_field = '%s.%s' % (identifier, q.field.attname)        
+            value_exp   = '%s!' % value_field
+        return '( HAS(%s) AND %s)' % ( value_field, cypher_predicate_from_condition(value_exp, q), )
     children = list(not_none(cypher_predicates_from_q(c) for c in q.children))
     if len(children) > 0:
         expr = (" %s " % q.connector).join(children)


### PR DESCRIPTION
Hi,

I noticed that when some nodes don't have the property used by "__icontains", the `!` that allows nullable property doesn't work properly. It causes a "java.lang.NullPointerException". To avoid that, I added a "HAS" function just before calling the `cypher_predicate_from_condition`.

Note that it is failing such as the upstream but this patch works.

All the best,
Pierre
