### PR TITLE
Added verbose_name to BoundRelationship's route

### DIFF
--- a/neo4django/db/models/relationships.py
+++ b/neo4django/db/models/relationships.py
@@ -149,10 +149,10 @@ class Relationship(object):
             raise TypeError("Relationships may only extend from Nodes.")
         self.creation_counter = source.creation_counter
 
-        # XXX this is to cover strange situations like accidental overriding 
-        # of abstract models' reverse relationships like issue #190 
-        if hasattr(source, name): 
-            return 
+        # XXX this is to cover strange situations like accidental overriding
+        # of abstract models' reverse relationships like issue #190
+        if hasattr(source, name):
+            return
 
         # make sure this relationship doesn't overlap with another of the same
         # type and direction
@@ -239,6 +239,7 @@ class BoundRelationship(AttrRouter, DeferredAttribute):
                      'meta',
                      'get_internal_type',
                      'help_text',
+                     'verbose_name',
                      'null',
                      'has_default',
                      # form handling


### PR DESCRIPTION
Hi,

the verbose_name support was missing for relationships... It's now fixed ;)

Very best,

Pierre
